### PR TITLE
Harris/lowheiser add cylinderhead temp max param

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -6623,7 +6623,7 @@ class AutoTestCopter(AutoTest):
 
         self.progress("Checking battery reset")
         self.run_cmd(mavutil.mavlink.MAV_CMD_BATTERY_RESET,
-                     (1<<2), # param1 - bitmask of batteries to reset
+                     (1 << 2), # param1 - bitmask of batteries to reset
                      100, # level to reset to
                      0, # param3
                      0, # param4

--- a/libraries/AP_Generator/AP_Generator_Loweheiser.cpp
+++ b/libraries/AP_Generator/AP_Generator_Loweheiser.cpp
@@ -62,6 +62,8 @@ const AP_Param::GroupInfo AP_Generator_Loweheiser::var_info[] = {
 
 void AP_Generator_Loweheiser::init()
 {
+    AP_Param::setup_object_defaults(this, var_info);
+
     _frontend._has_consumed_energy = true;
 
     if (time_until_maintenance == 0) {

--- a/libraries/AP_Generator/AP_Generator_Loweheiser.cpp
+++ b/libraries/AP_Generator/AP_Generator_Loweheiser.cpp
@@ -48,6 +48,13 @@ const AP_Param::GroupInfo AP_Generator_Loweheiser::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("IDLE_TEMP", 15, AP_Generator_Loweheiser, temp_required_for_idle, 110),
 
+    // @Param: OVER_TEMP
+    // @DisplayName: Cylinder Head Over Temperature Warning Level
+    // @Description: threshold temperature for the cylinder head above which the mavlink over temperature message gets sent
+    // @Units: degC
+    // @User: Advanced
+    AP_GROUPINFO("OVER_TEMP", 16, AP_Generator_Loweheiser, temp_for_overtemp_warning, 205),
+
     // Param indexes must be between 10 and 19 to avoid conflict with other generator param tables loaded by pointer
 
     AP_GROUPEND

--- a/libraries/AP_Generator/AP_Generator_Loweheiser.cpp
+++ b/libraries/AP_Generator/AP_Generator_Loweheiser.cpp
@@ -784,6 +784,7 @@ void AP_Generator_Loweheiser::Log_Write()
 // @Field: RPM: generator RPM
 // @Field: PW: EFI pulse-width
 // @Field: FF: fuel flow
+// @Field: FC: fuel consumed
 // @Field: EP: EFI pressure
 // @Field: EMT: EFI manifold air temperature
 // @Field: CHT: cylinder head temperature

--- a/libraries/AP_Generator/AP_Generator_Loweheiser.h
+++ b/libraries/AP_Generator/AP_Generator_Loweheiser.h
@@ -134,11 +134,6 @@ private:
     // prepare and send commands to generator:
     void command_generator();
 
-    // threshold temperature (degC) for when the mavlink
-    // overtemperature bit should be set.  Might want a parameter for
-    // this:
-    static constexpr float temp_for_overtemp_warning = 190;
-
     // log data to onboard storage:
     void Log_Write();
     uint32_t last_logged_reading_ms;
@@ -156,6 +151,7 @@ private:
     AP_Float idle_throttle;
     AP_Float temp_required_for_run;
     AP_Float temp_required_for_idle;
+    AP_Float temp_for_overtemp_warning;
 
     // update runtime and maintenance-required time
     void update_stats();


### PR DESCRIPTION
Adds an over temperature cylinder head parameter
Fixes the parameter defaults not getting setup initially
fixes a few minor autotest failures (still a few more that happen on unrelated vehicles??)