### PR TITLE
Ainstein LR-D1 updates: snr reading, malfunction codes, and override function

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LR_D1.h
@@ -45,17 +45,19 @@ private:
 
     // 0 is no return value, 100 is perfect.  false means signal
     // quality is not available
-    bool get_signal_quality_pct(uint8_t &quality_pct) const override;
+    int8_t get_signal_quality_pct() const override;
 
     // find signature byte in buffer starting at start, moving that
     // byte and following bytes to start of buffer.
     bool move_signature_in_buffer(uint8_t start);
 
+    void check_for_malfunction();
+
     enum class MalfunctionAlert {
         Temperature = 0x01,
         Voltage = 0x02,
-        IFSignalSaturation = 0x04,
-        AltitudeReading = 0x08,
+        IFSignalSaturation = 0x40,
+        AltitudeReading = 0x80,
     };
 
     union LRD1Union {
@@ -65,7 +67,7 @@ private:
             uint8_t device_id;
             uint8_t length;  // "fixed as 28 bytes"
             uint8_t malfunction_alert;
-            uint8_t objects_number;  // "fixed as 1"
+            uint8_t objects_number;  // "fixed as 1 (in version FW 6.0.7.x only), no longer reliable for data validation checks"
             uint16_t object1_alt;
             uint8_t object1_snr;
             uint16_t object1_velocity;
@@ -80,6 +82,7 @@ private:
     uint8_t buffer_used;
 
     uint8_t snr = 255;  // stashed SNR value after successful reading; 255 is unknown
+    int8_t signal_quality_pct = RangeFinder::SIGNAL_QUALITY_UNKNOWN;    
 };
 
 #endif  // AP_RANGEFINDER_AINSTEIN_LR_D1_ENABLED

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
@@ -10,7 +10,7 @@ const AP_Param::GroupInfo AP_RangeFinder_Params::var_info[] = {
     // @Param: TYPE
     // @DisplayName: Rangefinder type
     // @Description: Type of connected rangefinder
-    // @Values: 0:None,1:Analog,2:MaxbotixI2C,3:LidarLite-I2C,5:PWM,6:BBB-PRU,7:LightWareI2C,8:LightWareSerial,9:Bebop,10:MAVLink,11:USD1_Serial,12:LeddarOne,13:MaxbotixSerial,14:TeraRangerI2C,15:LidarLiteV3-I2C,16:VL53L0X or VL53L1X,17:NMEA,18:WASP-LRF,19:BenewakeTF02,20:Benewake-Serial,21:LidarLightV3HP,22:PWM,23:BlueRoboticsPing,24:DroneCAN,25:BenewakeTFminiPlus-I2C,26:LanbaoPSK-CM8JL65-CC5,27:BenewakeTF03,28:VL53L1X-ShortRange,29:LeddarVu8-Serial,30:HC-SR04,31:GYUS42v2,32:MSP,33:USD1_CAN,34:Benewake_CAN,35:TeraRangerSerial,36:Lua_Scripting,37:NoopLoop_TOFSense,38:NoopLoop_TOFSense_CAN,39:NRA24_CAN,40:NoopLoop_TOFSenseF_I2C,41:JRE_Serial,100:SITL
+    // @Values: 0:None,1:Analog,2:MaxbotixI2C,3:LidarLite-I2C,5:PWM,6:BBB-PRU,7:LightWareI2C,8:LightWareSerial,9:Bebop,10:MAVLink,11:USD1_Serial,12:LeddarOne,13:MaxbotixSerial,14:TeraRangerI2C,15:LidarLiteV3-I2C,16:VL53L0X or VL53L1X,17:NMEA,18:WASP-LRF,19:BenewakeTF02,20:Benewake-Serial,21:LidarLightV3HP,22:PWM,23:BlueRoboticsPing,24:DroneCAN,25:BenewakeTFminiPlus-I2C,26:LanbaoPSK-CM8JL65-CC5,27:BenewakeTF03,28:VL53L1X-ShortRange,29:LeddarVu8-Serial,30:HC-SR04,31:GYUS42v2,32:MSP,33:USD1_CAN,34:Benewake_CAN,35:TeraRangerSerial,36:Lua_Scripting,37:NoopLoop_TOFSense,38:NoopLoop_TOFSense_CAN,39:NRA24_CAN,40:NoopLoop_TOFSenseF_I2C,41:JRE_Serial,42:Ainstein_LR_D1,100:SITL
     // @User: Standard
     AP_GROUPINFO_FLAGS("TYPE", 1, AP_RangeFinder_Params, type, 0, AP_PARAM_FLAG_ENABLE),
 


### PR DESCRIPTION
Updates include the following:

- FW Version 18.x rearranged data words 5 & 6. This removed the ability to count on data6 always being 0x01. Removed it as a validation check
- Updated `get_signal_quality_pct`, was unable to compile using the previous implementation.
- Added additional SNR checking for 'invalid altitude readings' according to the datasheet.
- Corrected malfunction codes and added reporting for 'Stop use and check' alert codes.

**This has only been tested on bench top, still awaiting flight testing.**


@peterbarker Let me know if you have any questions. Will be flight testing this month. 



Feel free to comment as you see fit! Thanks.