### PR TITLE
Remove use of OwnPtr in AP_Compass

### DIFF
--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -1564,6 +1564,17 @@ void Compass::probe_ak8963_via_mpu9250(uint8_t imu_instance, Rotation rotation)
     auto *backend = AP_Compass_AK8963::probe_mpu9250(imu_instance, rotation);
     add_backend(DRIVER_AK8963, backend);  // add_backend does nullptr check
 }
+void Compass::probe_ak8963_via_mpu9250(uint8_t i2c_bus, uint8_t ak8963_addr, Rotation rotation)
+{
+    if (!_driver_enabled(DRIVER_AK8963)) {
+        return;
+    }
+    auto *backend = AP_Compass_AK8963::probe_mpu9250(
+        GET_I2C_DEVICE(i2c_bus, ak8963_addr),
+        rotation
+    );
+    add_backend(DRIVER_AK8963, backend);  // add_backend does nullptr check
+}
 #endif  // AP_COMPASS_AK8963_ENABLED
 
 #if AP_COMPASS_AK09916_ENABLED && AP_COMPASS_ICM20948_ENABLED
@@ -1609,6 +1620,18 @@ void Compass::probe_i2c_dev(DriverType driver_type, probe_i2c_dev_probefn_t prob
     add_backend(driver_type, backend);  // add_backend does nullptr check
 }
 
+// short-lived method which expects a probe function that doesn't
+// offer the ability to specify the compass as external:
+void Compass::probe_i2c_dev(DriverType driver_type, probe_i2c_dev_noexternal_probefn_t probefn, uint8_t i2c_bus, uint8_t i2c_addr, Rotation rotation)
+{
+    if (!_driver_enabled(driver_type)) {
+        return;
+    }
+    auto *backend = probefn(GET_I2C_DEVICE(i2c_bus, i2c_addr), rotation);
+
+    add_backend(driver_type, backend);  // add_backend does nullptr check
+}
+
 void Compass::probe_spi_dev(DriverType driver_type, probe_spi_dev_probefn_t probefn, const char *name, bool external, Rotation rotation)
 {
     if (!_driver_enabled(driver_type)) {
@@ -1619,7 +1642,7 @@ void Compass::probe_spi_dev(DriverType driver_type, probe_spi_dev_probefn_t prob
     add_backend(driver_type, backend);  // add_backend does nullptr check
 }
 
-// short-lived method which expectes a probe function that doesn't
+// short-lived method which expects a probe function that doesn't
 // offer the ability to specify an external rotation:
 void Compass::probe_spi_dev(DriverType driver_type, probe_spi_dev_noexternal_probefn_t probefn, const char *name, Rotation rotation)
 {

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -1092,6 +1092,10 @@ bool Compass::_i2c_sensor_is_registered(uint8_t bus, uint8_t address) const
 /*
   macro to add a backend with check for too many backends or compass
   instances. We don't try to start more than the maximum allowed
+
+  several callers assume this method will not fail if the driver has
+  not been disabled.  If you add extra return-early clauses here check
+  all callers.
  */
 void Compass::add_backend(Compass::DriverType driver_type, AP_Compass_Backend *backend)
 {
@@ -1111,6 +1115,7 @@ void Compass::add_backend(Compass::DriverType driver_type, AP_Compass_Backend *b
 }
 
 #define GET_I2C_DEVICE(bus, address) _i2c_sensor_is_registered(bus, address)?nullptr:hal.i2c_mgr->get_device(bus, address)
+#define GET_I2C_DEVICE_PTR(bus, address) _i2c_sensor_is_registered(bus, address)?nullptr:hal.i2c_mgr->get_device_ptr(bus, address)
 
 /*
   look for compasses on external i2c buses
@@ -1569,11 +1574,19 @@ void Compass::probe_ak8963_via_mpu9250(uint8_t i2c_bus, uint8_t ak8963_addr, Rot
     if (!_driver_enabled(DRIVER_AK8963)) {
         return;
     }
+    auto *dev = GET_I2C_DEVICE_PTR(i2c_bus, ak8963_addr);
+    if (dev == nullptr) {
+        return;
+    }
     auto *backend = AP_Compass_AK8963::probe_mpu9250(
-        GET_I2C_DEVICE(i2c_bus, ak8963_addr),
+        *dev,
         rotation
     );
-    add_backend(DRIVER_AK8963, backend);  // add_backend does nullptr check
+    if (backend == nullptr) {
+        delete dev;
+        return;
+    }
+    add_backend(DRIVER_AK8963, backend);
 }
 #endif  // AP_COMPASS_AK8963_ENABLED
 
@@ -1583,14 +1596,26 @@ void Compass::probe_ak09916_via_icm20948(uint8_t i2c_bus, uint8_t ak09916_addr, 
     if (!_driver_enabled(DRIVER_ICM20948)) {
         return;
     }
+    auto *ak09916_dev = GET_I2C_DEVICE_PTR(i2c_bus, ak09916_addr);
+    auto *icm20948_dev = GET_I2C_DEVICE_PTR(i2c_bus, icm20948_addr);
+    if (ak09916_dev == nullptr || icm20948_dev == nullptr) {
+        delete ak09916_dev;
+        delete icm20948_dev;
+        return;
+    }
     auto *backend = AP_Compass_AK09916::probe_ICM20948(
-        GET_I2C_DEVICE(i2c_bus, ak09916_addr),
-        GET_I2C_DEVICE(i2c_bus, icm20948_addr),
+        *ak09916_dev,
+        *icm20948_dev,
         external,
         rotation
         );
+    if (backend == nullptr) {
+        delete ak09916_dev;
+        delete icm20948_dev;
+        return;
+    }
 
-    add_backend(DRIVER_ICM20948, backend);  // add_backend does nullptr check
+    add_backend(DRIVER_ICM20948, backend);
 }
 
 void Compass::probe_ak09916_via_icm20948(uint8_t ins_instance, Rotation rotation)
@@ -1611,13 +1636,21 @@ void Compass::probe_i2c_dev(DriverType driver_type, probe_i2c_dev_probefn_t prob
     if (!_driver_enabled(driver_type)) {
         return;
     }
+    auto *dev = GET_I2C_DEVICE_PTR(i2c_bus, i2c_addr);
+    if (dev == nullptr) {
+        return;
+    }
     auto *backend = probefn(
-        GET_I2C_DEVICE(i2c_bus, i2c_addr),
+        *dev,
         external,
         rotation
         );
+    if (backend == nullptr) {
+        delete dev;
+        return;
+    }
 
-    add_backend(driver_type, backend);  // add_backend does nullptr check
+    add_backend(driver_type, backend);
 }
 
 // short-lived method which expects a probe function that doesn't
@@ -1627,9 +1660,17 @@ void Compass::probe_i2c_dev(DriverType driver_type, probe_i2c_dev_noexternal_pro
     if (!_driver_enabled(driver_type)) {
         return;
     }
-    auto *backend = probefn(GET_I2C_DEVICE(i2c_bus, i2c_addr), rotation);
+    auto *dev = GET_I2C_DEVICE_PTR(i2c_bus, i2c_addr);
+    if (dev == nullptr) {
+        return;
+    }
+    auto *backend = probefn(*dev, rotation);
+    if (backend == nullptr) {
+        delete dev;
+        return;
+    }
 
-    add_backend(driver_type, backend);  // add_backend does nullptr check
+    add_backend(driver_type, backend);
 }
 
 void Compass::probe_spi_dev(DriverType driver_type, probe_spi_dev_probefn_t probefn, const char *name, bool external, Rotation rotation)
@@ -1637,9 +1678,17 @@ void Compass::probe_spi_dev(DriverType driver_type, probe_spi_dev_probefn_t prob
     if (!_driver_enabled(driver_type)) {
         return;
     }
-    auto *backend = probefn(hal.spi->get_device(name), external, rotation);
+    auto *dev = hal.spi->get_device_ptr(name);
+    if (dev == nullptr) {
+        return;
+    }
+    auto *backend = probefn(*dev, external, rotation);
+    if (backend == nullptr) {
+        delete dev;
+        return;
+    }
 
-    add_backend(driver_type, backend);  // add_backend does nullptr check
+    add_backend(driver_type, backend);
 }
 
 // short-lived method which expects a probe function that doesn't
@@ -1649,9 +1698,17 @@ void Compass::probe_spi_dev(DriverType driver_type, probe_spi_dev_noexternal_pro
     if (!_driver_enabled(driver_type)) {
         return;
     }
-    auto *backend = probefn(hal.spi->get_device(name), rotation);
+    auto *dev = hal.spi->get_device_ptr(name);
+    if (dev == nullptr) {
+        return;
+    }
+    auto *backend = probefn(*dev, rotation);
+    if (backend == nullptr) {
+        delete dev;
+        return;
+    }
 
-    add_backend(driver_type, backend);  // add_backend does nullptr check
+    add_backend(driver_type, backend);
 }
 
 #if AP_COMPASS_DRONECAN_ENABLED

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -505,10 +505,16 @@ private:
     // helper probe functions
     void probe_ak09916_via_icm20948(uint8_t i2c_bus, uint8_t ak09916_addr, uint8_t icm20948_addr, bool external, Rotation rotation);
     void probe_ak09916_via_icm20948(uint8_t ins_instance, Rotation rotation);
+    void probe_ak8963_via_mpu9250(uint8_t i2c_bus, uint8_t ak8963_addr, Rotation rotation);
     void probe_ak8963_via_mpu9250(uint8_t imu_instance, Rotation rotation);
 
     using probe_i2c_dev_probefn_t = AP_Compass_Backend* (*)(AP_HAL::OwnPtr<AP_HAL::Device>, bool, Rotation);
     void probe_i2c_dev(DriverType driver_type, probe_i2c_dev_probefn_t probefn, uint8_t i2c_bus, uint8_t i2c_addr, bool external, Rotation rotation);
+
+    // short-lived method which expects a probe function that doesn't
+    // offer the ability to specify the compass as external:
+    using probe_i2c_dev_noexternal_probefn_t = AP_Compass_Backend* (*)(AP_HAL::OwnPtr<AP_HAL::Device>, Rotation);
+    void probe_i2c_dev(DriverType driver_type, probe_i2c_dev_noexternal_probefn_t, uint8_t i2c_bus, uint8_t i2c_addr, Rotation rotation);
 
     using probe_spi_dev_probefn_t = AP_Compass_Backend* (*)(AP_HAL::OwnPtr<AP_HAL::Device>, bool, Rotation);
     void probe_spi_dev(DriverType driver_type, probe_spi_dev_probefn_t probefn, const char *name, bool external, Rotation rotation);

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -508,19 +508,19 @@ private:
     void probe_ak8963_via_mpu9250(uint8_t i2c_bus, uint8_t ak8963_addr, Rotation rotation);
     void probe_ak8963_via_mpu9250(uint8_t imu_instance, Rotation rotation);
 
-    using probe_i2c_dev_probefn_t = AP_Compass_Backend* (*)(AP_HAL::OwnPtr<AP_HAL::Device>, bool, Rotation);
+    using probe_i2c_dev_probefn_t = AP_Compass_Backend* (*)(AP_HAL::Device&, bool, Rotation);
     void probe_i2c_dev(DriverType driver_type, probe_i2c_dev_probefn_t probefn, uint8_t i2c_bus, uint8_t i2c_addr, bool external, Rotation rotation);
 
     // short-lived method which expects a probe function that doesn't
     // offer the ability to specify the compass as external:
-    using probe_i2c_dev_noexternal_probefn_t = AP_Compass_Backend* (*)(AP_HAL::OwnPtr<AP_HAL::Device>, Rotation);
+    using probe_i2c_dev_noexternal_probefn_t = AP_Compass_Backend* (*)(AP_HAL::Device&, Rotation);
     void probe_i2c_dev(DriverType driver_type, probe_i2c_dev_noexternal_probefn_t, uint8_t i2c_bus, uint8_t i2c_addr, Rotation rotation);
 
-    using probe_spi_dev_probefn_t = AP_Compass_Backend* (*)(AP_HAL::OwnPtr<AP_HAL::Device>, bool, Rotation);
+    using probe_spi_dev_probefn_t = AP_Compass_Backend* (*)(AP_HAL::Device&, bool, Rotation);
     void probe_spi_dev(DriverType driver_type, probe_spi_dev_probefn_t probefn, const char *name, bool external, Rotation rotation);
     // short-lived method which expects a probe function that doesn't
     // offer the ability to specify an external rotation
-    using probe_spi_dev_noexternal_probefn_t = AP_Compass_Backend* (*)(AP_HAL::OwnPtr<AP_HAL::Device>, Rotation);
+    using probe_spi_dev_noexternal_probefn_t = AP_Compass_Backend* (*)(AP_HAL::Device&, Rotation);
     void probe_spi_dev(DriverType driver_type, probe_spi_dev_noexternal_probefn_t probefn, const char *name, Rotation rotation);
 
     // backend objects

--- a/libraries/AP_Compass/AP_Compass_AK09916.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK09916.cpp
@@ -199,9 +199,12 @@ AP_Compass_Backend *AP_Compass_AK09916::probe_ICM20948_I2C(uint8_t inv2_instance
     }
 
     AP_Compass_AK09916 *sensor = NEW_NOTHROW AP_Compass_AK09916(*bus, false, rotation);
-    if (!sensor || !sensor->init()) {
-        // TODO: do we need to "delete bus;" here?
-        delete sensor;
+    if (sensor == nullptr) {
+        delete bus;
+        return nullptr;
+    }
+    if (!sensor->init()) {
+        delete sensor;  // sensor's destructor deletes bus
         return nullptr;
     }
 

--- a/libraries/AP_Compass/AP_Compass_AK09916.h
+++ b/libraries/AP_Compass/AP_Compass_AK09916.h
@@ -48,14 +48,14 @@ class AP_Compass_AK09916 : public AP_Compass_Backend
 {
 public:
     /* Probe for AK09916 standalone on I2C bus */
-    static AP_Compass_Backend *probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+    static AP_Compass_Backend *probe(AP_HAL::Device &dev,
                                      bool force_external,
                                      enum Rotation rotation);
 
 #if AP_COMPASS_ICM20948_ENABLED
     /* Probe for AK09916 on auxiliary bus of ICM20948, connected through I2C */
-    static AP_Compass_Backend *probe_ICM20948(AP_HAL::OwnPtr<AP_HAL::Device> dev,
-                                             AP_HAL::OwnPtr<AP_HAL::Device> dev_icm,
+    static AP_Compass_Backend *probe_ICM20948(AP_HAL::Device &dev,
+                                             AP_HAL::Device &dev_icm,
                                              bool force_external,
                                              enum Rotation rotation);
 
@@ -84,7 +84,7 @@ public:
     };
 
 private:
-    AP_Compass_AK09916(AP_AK09916_BusDriver *bus, bool force_external,
+    AP_Compass_AK09916(AP_AK09916_BusDriver &bus, bool force_external,
                        enum Rotation rotation);
 
     bool init();
@@ -141,7 +141,7 @@ public:
 class AP_AK09916_BusDriver_HALDevice: public AP_AK09916_BusDriver
 {
 public:
-    AP_AK09916_BusDriver_HALDevice(AP_HAL::OwnPtr<AP_HAL::Device> dev);
+    AP_AK09916_BusDriver_HALDevice(AP_HAL::Device &dev);
 
     virtual bool block_read(uint8_t reg, uint8_t *buf, uint32_t size) override;
     virtual bool register_read(uint8_t reg, uint8_t *val) override;
@@ -173,7 +173,7 @@ public:
     }
     
 private:
-    AP_HAL::OwnPtr<AP_HAL::Device> _dev;
+    AP_HAL::Device *_dev;
 };
 
 class AP_AK09916_BusDriver_Auxiliary : public AP_AK09916_BusDriver

--- a/libraries/AP_Compass/AP_Compass_AK8963.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK8963.cpp
@@ -71,9 +71,12 @@ AP_Compass_Backend *AP_Compass_AK8963::probe(AP_HAL::Device &dev,
     }
 
     AP_Compass_AK8963 *sensor = NEW_NOTHROW AP_Compass_AK8963(*bus, rotation);
-    if (!sensor || !sensor->init()) {
-        // TODO: do we need to "delete bus;" here?
-        delete sensor;
+    if (sensor == nullptr) {
+        delete bus;
+        return nullptr;
+    }
+    if (!sensor->init()) {
+        delete sensor;  // sensor's destructor deletes bus
         return nullptr;
     }
 
@@ -106,9 +109,12 @@ AP_Compass_Backend *AP_Compass_AK8963::probe_mpu9250(uint8_t mpu9250_instance,
     }
 
     AP_Compass_AK8963 *sensor = NEW_NOTHROW AP_Compass_AK8963(*bus, rotation);
-    if (!sensor || !sensor->init()) {
-        // TODO: do we need to "delete bus" here?
-        delete sensor;
+    if (sensor == nullptr) {
+        delete bus;
+        return nullptr;
+    }
+    if (!sensor->init()) {
+        delete sensor;  // sensor's destructor deletes bus
         return nullptr;
     }
 

--- a/libraries/AP_Compass/AP_Compass_AK8963.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK8963.cpp
@@ -18,7 +18,6 @@
 #if AP_COMPASS_AK8963_ENABLED
 
 #include <assert.h>
-#include <utility>
 
 #include <AP_Math/AP_Math.h>
 #include <AP_HAL/AP_HAL.h>
@@ -51,9 +50,9 @@
 
 extern const AP_HAL::HAL &hal;
 
-AP_Compass_AK8963::AP_Compass_AK8963(AP_AK8963_BusDriver *bus,
+AP_Compass_AK8963::AP_Compass_AK8963(AP_AK8963_BusDriver &bus,
                                      enum Rotation rotation)
-    : _bus(bus)
+    : _bus(&bus)
     , _rotation(rotation)
 {
 }
@@ -63,19 +62,17 @@ AP_Compass_AK8963::~AP_Compass_AK8963()
     delete _bus;
 }
 
-AP_Compass_Backend *AP_Compass_AK8963::probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+AP_Compass_Backend *AP_Compass_AK8963::probe(AP_HAL::Device &dev,
                                              enum Rotation rotation)
 {
-    if (!dev) {
-        return nullptr;
-    }
-    AP_AK8963_BusDriver *bus = NEW_NOTHROW AP_AK8963_BusDriver_HALDevice(std::move(dev));
+    AP_AK8963_BusDriver *bus = NEW_NOTHROW AP_AK8963_BusDriver_HALDevice(dev);
     if (!bus) {
         return nullptr;
     }
 
-    AP_Compass_AK8963 *sensor = NEW_NOTHROW AP_Compass_AK8963(bus, rotation);
+    AP_Compass_AK8963 *sensor = NEW_NOTHROW AP_Compass_AK8963(*bus, rotation);
     if (!sensor || !sensor->init()) {
+        // TODO: do we need to "delete bus;" here?
         delete sensor;
         return nullptr;
     }
@@ -83,12 +80,9 @@ AP_Compass_Backend *AP_Compass_AK8963::probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
     return sensor;
 }
 
-AP_Compass_Backend *AP_Compass_AK8963::probe_mpu9250(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+AP_Compass_Backend *AP_Compass_AK8963::probe_mpu9250(AP_HAL::Device &dev,
                                                      enum Rotation rotation)
 {
-    if (!dev) {
-        return nullptr;
-    }
 #if AP_INERTIALSENSOR_ENABLED
     AP_InertialSensor &ins = *AP_InertialSensor::get_singleton();
 
@@ -96,7 +90,7 @@ AP_Compass_Backend *AP_Compass_AK8963::probe_mpu9250(AP_HAL::OwnPtr<AP_HAL::Devi
     ins.detect_backends();
 #endif
 
-    return probe(std::move(dev), rotation);
+    return probe(dev, rotation);
 }
 
 AP_Compass_Backend *AP_Compass_AK8963::probe_mpu9250(uint8_t mpu9250_instance,
@@ -111,8 +105,9 @@ AP_Compass_Backend *AP_Compass_AK8963::probe_mpu9250(uint8_t mpu9250_instance,
         return nullptr;
     }
 
-    AP_Compass_AK8963 *sensor = NEW_NOTHROW AP_Compass_AK8963(bus, rotation);
+    AP_Compass_AK8963 *sensor = NEW_NOTHROW AP_Compass_AK8963(*bus, rotation);
     if (!sensor || !sensor->init()) {
+        // TODO: do we need to "delete bus" here?
         delete sensor;
         return nullptr;
     }
@@ -272,8 +267,8 @@ bool AP_Compass_AK8963::_calibrate()
 }
 
 /* AP_HAL::Device implementation of the AK8963 */
-AP_AK8963_BusDriver_HALDevice::AP_AK8963_BusDriver_HALDevice(AP_HAL::OwnPtr<AP_HAL::Device> dev)
-    : _dev(std::move(dev))
+AP_AK8963_BusDriver_HALDevice::AP_AK8963_BusDriver_HALDevice(AP_HAL::Device &dev)
+    : _dev(&dev)
 {
 }
 

--- a/libraries/AP_Compass/AP_Compass_AK8963.h
+++ b/libraries/AP_Compass/AP_Compass_AK8963.h
@@ -21,11 +21,11 @@ class AP_Compass_AK8963 : public AP_Compass_Backend
 {
 public:
     /* Probe for AK8963 standalone on I2C bus */
-    static AP_Compass_Backend *probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+    static AP_Compass_Backend *probe(AP_HAL::Device &dev,
                                      enum Rotation rotation);
 
     /* Probe for AK8963 on auxiliary bus of MPU9250, connected through I2C */
-    static AP_Compass_Backend *probe_mpu9250(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+    static AP_Compass_Backend *probe_mpu9250(AP_HAL::Device &dev,
                                              enum Rotation rotation);
 
     /* Probe for AK8963 on auxiliary bus of MPU9250, connected through SPI */
@@ -45,7 +45,7 @@ public:
     };
 
 private:
-    AP_Compass_AK8963(AP_AK8963_BusDriver *bus,
+    AP_Compass_AK8963(AP_AK8963_BusDriver &bus,
                       enum Rotation rotation);
 
     bool init();
@@ -92,7 +92,7 @@ public:
 class AP_AK8963_BusDriver_HALDevice: public AP_AK8963_BusDriver
 {
 public:
-    AP_AK8963_BusDriver_HALDevice(AP_HAL::OwnPtr<AP_HAL::Device> dev);
+    AP_AK8963_BusDriver_HALDevice(AP_HAL::Device &dev);
 
     virtual bool block_read(uint8_t reg, uint8_t *buf, uint32_t size) override;
     virtual bool register_read(uint8_t reg, uint8_t *val) override;
@@ -112,7 +112,7 @@ public:
     }
     
 private:
-    AP_HAL::OwnPtr<AP_HAL::Device> _dev;
+    AP_HAL::Device *_dev;
 };
 
 class AP_AK8963_BusDriver_Auxiliary : public AP_AK8963_BusDriver

--- a/libraries/AP_Compass/AP_Compass_BMM150.cpp
+++ b/libraries/AP_Compass/AP_Compass_BMM150.cpp
@@ -20,8 +20,6 @@
 
 #include <AP_HAL/AP_HAL.h>
 
-#include <utility>
-
 #include <AP_HAL/utility/sparse-endian.h>
 #include <AP_Math/AP_Math.h>
 #include <stdio.h>
@@ -65,12 +63,9 @@
 
 extern const AP_HAL::HAL &hal;
 
-AP_Compass_Backend *AP_Compass_BMM150::probe(AP_HAL::OwnPtr<AP_HAL::Device> dev, bool force_external, enum Rotation rotation)
+AP_Compass_Backend *AP_Compass_BMM150::probe(AP_HAL::Device &dev, bool force_external, enum Rotation rotation)
 {
-    if (!dev) {
-        return nullptr;
-    }
-    AP_Compass_BMM150 *sensor = NEW_NOTHROW AP_Compass_BMM150(std::move(dev), force_external, rotation);
+    AP_Compass_BMM150 *sensor = NEW_NOTHROW AP_Compass_BMM150(dev, force_external, rotation);
     if (!sensor || !sensor->init()) {
         delete sensor;
         return nullptr;
@@ -79,8 +74,8 @@ AP_Compass_Backend *AP_Compass_BMM150::probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
     return sensor;
 }
 
-AP_Compass_BMM150::AP_Compass_BMM150(AP_HAL::OwnPtr<AP_HAL::Device> dev, bool force_external, enum Rotation rotation)
-    : _dev(std::move(dev)), _rotation(rotation), _force_external(force_external)
+AP_Compass_BMM150::AP_Compass_BMM150(AP_HAL::Device &dev, bool force_external, enum Rotation rotation)
+    : _dev(&dev), _rotation(rotation), _force_external(force_external)
 {
 }
 

--- a/libraries/AP_Compass/AP_Compass_BMM150.h
+++ b/libraries/AP_Compass/AP_Compass_BMM150.h
@@ -34,12 +34,12 @@
 class AP_Compass_BMM150 : public AP_Compass_Backend
 {
 public:
-    static AP_Compass_Backend *probe(AP_HAL::OwnPtr<AP_HAL::Device> dev, bool force_external, enum Rotation rotation);
+    static AP_Compass_Backend *probe(AP_HAL::Device &dev, bool force_external, enum Rotation rotation);
 
     static constexpr const char *name = "BMM150";
 
 private:
-    AP_Compass_BMM150(AP_HAL::OwnPtr<AP_HAL::Device> dev, bool force_external, enum Rotation rotation);
+    AP_Compass_BMM150(AP_HAL::Device &dev, bool force_external, enum Rotation rotation);
 
     /**
      * Device periodic callback to read data from the sensor.
@@ -50,7 +50,7 @@ private:
     int16_t _compensate_xy(int16_t xy, uint32_t rhall, int32_t txy1, int32_t txy2) const;
     int16_t _compensate_z(int16_t z, uint32_t rhall) const;
 
-    AP_HAL::OwnPtr<AP_HAL::Device> _dev;
+    AP_HAL::Device *_dev;
 
     struct {
         int8_t x1;

--- a/libraries/AP_Compass/AP_Compass_BMM350.cpp
+++ b/libraries/AP_Compass/AP_Compass_BMM350.cpp
@@ -18,8 +18,6 @@
 
 #include <AP_HAL/AP_HAL.h>
 
-#include <utility>
-
 #include <AP_HAL/utility/sparse-endian.h>
 #include <AP_Math/AP_Math.h>
 
@@ -107,14 +105,11 @@
 
 extern const AP_HAL::HAL &hal;
 
-AP_Compass_Backend *AP_Compass_BMM350::probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+AP_Compass_Backend *AP_Compass_BMM350::probe(AP_HAL::Device &dev,
                                               bool force_external,
                                               enum Rotation rotation)
 {
-    if (!dev) {
-        return nullptr;
-    }
-    AP_Compass_BMM350 *sensor = NEW_NOTHROW AP_Compass_BMM350(std::move(dev), force_external, rotation);
+    AP_Compass_BMM350 *sensor = NEW_NOTHROW AP_Compass_BMM350(dev, force_external, rotation);
     if (!sensor || !sensor->init()) {
         delete sensor;
         return nullptr;
@@ -123,10 +118,10 @@ AP_Compass_Backend *AP_Compass_BMM350::probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
     return sensor;
 }
 
-AP_Compass_BMM350::AP_Compass_BMM350(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+AP_Compass_BMM350::AP_Compass_BMM350(AP_HAL::Device &dev,
                                        bool force_external,
                                        enum Rotation rotation)
-    : _dev(std::move(dev))
+    : _dev(&dev)
     , _force_external(force_external)
     , _rotation(rotation)
 {

--- a/libraries/AP_Compass/AP_Compass_BMM350.h
+++ b/libraries/AP_Compass/AP_Compass_BMM350.h
@@ -34,18 +34,18 @@
 class AP_Compass_BMM350 : public AP_Compass_Backend
 {
 public:
-    static AP_Compass_Backend *probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+    static AP_Compass_Backend *probe(AP_HAL::Device &dev,
                                      bool force_external,
                                      enum Rotation rotation);
 
     static constexpr const char *name = "BMM350";
 
 private:
-    AP_Compass_BMM350(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+    AP_Compass_BMM350(AP_HAL::Device &dev,
                        bool force_external,
                        enum Rotation rotation);
 
-    AP_HAL::OwnPtr<AP_HAL::Device> _dev;
+    AP_HAL::Device *_dev;
 
     /**
      * @brief BMM350 offset/sensitivity coefficient structure

--- a/libraries/AP_Compass/AP_Compass_HMC5843.cpp
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.cpp
@@ -114,9 +114,12 @@ AP_Compass_Backend *AP_Compass_HMC5843::probe(AP_HAL::Device &dev,
     }
 
     AP_Compass_HMC5843 *sensor = NEW_NOTHROW AP_Compass_HMC5843(*bus, force_external, rotation);
-    if (!sensor || !sensor->init()) {
-        // TODO: do we need to "delete bus;" here?
-        delete sensor;
+    if (sensor == nullptr) {
+        delete bus;
+        return nullptr;
+    }
+    if (!sensor->init()) {
+        delete sensor;  // sensor's destructor deletes bus
         return nullptr;
     }
 

--- a/libraries/AP_Compass/AP_Compass_HMC5843.h
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.h
@@ -23,7 +23,7 @@ class AP_HMC5843_BusDriver;
 class AP_Compass_HMC5843 : public AP_Compass_Backend
 {
 public:
-    static AP_Compass_Backend *probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+    static AP_Compass_Backend *probe(AP_HAL::Device &dev,
                                      bool force_external,
                                      enum Rotation rotation);
 
@@ -38,7 +38,7 @@ public:
     void read() override;
 
 private:
-    AP_Compass_HMC5843(AP_HMC5843_BusDriver *bus,
+    AP_Compass_HMC5843(AP_HMC5843_BusDriver &bus,
                        bool force_external, enum Rotation rotation);
 
     bool init();
@@ -97,7 +97,7 @@ public:
 class AP_HMC5843_BusDriver_HALDevice : public AP_HMC5843_BusDriver
 {
 public:
-    AP_HMC5843_BusDriver_HALDevice(AP_HAL::OwnPtr<AP_HAL::Device> dev);
+    AP_HMC5843_BusDriver_HALDevice(AP_HAL::Device &dev);
 
     bool block_read(uint8_t reg, uint8_t *buf, uint32_t size) override;
     bool register_read(uint8_t reg, uint8_t *val) override;
@@ -122,7 +122,7 @@ public:
     }
     
 private:
-    AP_HAL::OwnPtr<AP_HAL::Device> _dev;
+    AP_HAL::Device *_dev;
 };
 
 #if AP_INERTIALSENSOR_ENABLED

--- a/libraries/AP_Compass/AP_Compass_IIS2MDC.cpp
+++ b/libraries/AP_Compass/AP_Compass_IIS2MDC.cpp
@@ -43,15 +43,11 @@
 
 extern const AP_HAL::HAL &hal;
 
-AP_Compass_Backend *AP_Compass_IIS2MDC::probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+AP_Compass_Backend *AP_Compass_IIS2MDC::probe(AP_HAL::Device &dev,
         bool force_external,
         enum Rotation rotation)
 {
-    if (!dev) {
-        return nullptr;
-    }
-
-    AP_Compass_IIS2MDC *sensor = NEW_NOTHROW AP_Compass_IIS2MDC(std::move(dev),force_external,rotation);
+    AP_Compass_IIS2MDC *sensor = NEW_NOTHROW AP_Compass_IIS2MDC(dev,force_external,rotation);
 
     if (!sensor || !sensor->init()) {
         delete sensor;
@@ -61,10 +57,10 @@ AP_Compass_Backend *AP_Compass_IIS2MDC::probe(AP_HAL::OwnPtr<AP_HAL::Device> dev
     return sensor;
 }
 
-AP_Compass_IIS2MDC::AP_Compass_IIS2MDC(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+AP_Compass_IIS2MDC::AP_Compass_IIS2MDC(AP_HAL::Device &dev,
         bool force_external,
         enum Rotation rotation)
-    : _dev(std::move(dev))
+    : _dev(&dev)
     , _rotation(rotation)
     , _force_external(force_external)
 {

--- a/libraries/AP_Compass/AP_Compass_IIS2MDC.h
+++ b/libraries/AP_Compass/AP_Compass_IIS2MDC.h
@@ -40,14 +40,14 @@
 class AP_Compass_IIS2MDC : public AP_Compass_Backend
 {
 public:
-    static AP_Compass_Backend *probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+    static AP_Compass_Backend *probe(AP_HAL::Device &dev,
                                      bool force_external,
                                      enum Rotation rotation);
 
     static constexpr const char *name = "IIS2MDC";
 
 private:
-    AP_Compass_IIS2MDC(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+    AP_Compass_IIS2MDC(AP_HAL::Device &dev,
                         bool force_external,
                         enum Rotation rotation);
 
@@ -55,7 +55,7 @@ private:
     void timer();
     bool init();
 
-    AP_HAL::OwnPtr<AP_HAL::Device> _dev;
+    AP_HAL::Device *_dev;
 
     enum Rotation _rotation;
     bool _force_external;

--- a/libraries/AP_Compass/AP_Compass_IST8308.cpp
+++ b/libraries/AP_Compass/AP_Compass_IST8308.cpp
@@ -19,7 +19,6 @@
 #if AP_COMPASS_IST8308_ENABLED
 
 #include <stdio.h>
-#include <utility>
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/utility/sparse-endian.h>
@@ -81,15 +80,11 @@
 
 extern const AP_HAL::HAL &hal;
 
-AP_Compass_Backend *AP_Compass_IST8308::probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+AP_Compass_Backend *AP_Compass_IST8308::probe(AP_HAL::Device &dev,
                                               bool force_external,
                                               enum Rotation rotation)
 {
-    if (!dev) {
-        return nullptr;
-    }
-
-    AP_Compass_IST8308 *sensor = NEW_NOTHROW AP_Compass_IST8308(std::move(dev), force_external, rotation);
+    AP_Compass_IST8308 *sensor = NEW_NOTHROW AP_Compass_IST8308(dev, force_external, rotation);
     if (!sensor || !sensor->init()) {
         delete sensor;
         return nullptr;
@@ -98,10 +93,10 @@ AP_Compass_Backend *AP_Compass_IST8308::probe(AP_HAL::OwnPtr<AP_HAL::Device> dev
     return sensor;
 }
 
-AP_Compass_IST8308::AP_Compass_IST8308(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+AP_Compass_IST8308::AP_Compass_IST8308(AP_HAL::Device &dev,
                                        bool force_external,
                                        enum Rotation rotation)
-    : _dev(std::move(dev))
+    : _dev(&dev)
     , _rotation(rotation)
     , _force_external(force_external)
 {

--- a/libraries/AP_Compass/AP_Compass_IST8308.h
+++ b/libraries/AP_Compass/AP_Compass_IST8308.h
@@ -33,21 +33,21 @@
 class AP_Compass_IST8308 : public AP_Compass_Backend
 {
 public:
-    static AP_Compass_Backend *probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+    static AP_Compass_Backend *probe(AP_HAL::Device &dev,
                                      bool force_external,
                                      enum Rotation rotation);
 
     static constexpr const char *name = "IST8308";
 
 private:
-    AP_Compass_IST8308(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+    AP_Compass_IST8308(AP_HAL::Device &dev,
                        bool force_external,
                        enum Rotation rotation);
 
     void timer();
     bool init();
 
-    AP_HAL::OwnPtr<AP_HAL::Device> _dev;
+    AP_HAL::Device *_dev;
 
     enum Rotation _rotation;
     bool _force_external;

--- a/libraries/AP_Compass/AP_Compass_IST8310.cpp
+++ b/libraries/AP_Compass/AP_Compass_IST8310.cpp
@@ -21,7 +21,6 @@
 #if AP_COMPASS_IST8310_ENABLED
 
 #include <stdio.h>
-#include <utility>
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/utility/sparse-endian.h>
@@ -78,15 +77,11 @@ static const int16_t IST8310_MIN_VAL_Z  = -IST8310_MAX_VAL_Z;
 
 extern const AP_HAL::HAL &hal;
 
-AP_Compass_Backend *AP_Compass_IST8310::probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+AP_Compass_Backend *AP_Compass_IST8310::probe(AP_HAL::Device &dev,
                                               bool force_external,
                                               enum Rotation rotation)
 {
-    if (!dev) {
-        return nullptr;
-    }
-
-    AP_Compass_IST8310 *sensor = NEW_NOTHROW AP_Compass_IST8310(std::move(dev), force_external, rotation);
+    AP_Compass_IST8310 *sensor = NEW_NOTHROW AP_Compass_IST8310(dev, force_external, rotation);
     if (!sensor || !sensor->init()) {
         delete sensor;
         return nullptr;
@@ -95,10 +90,10 @@ AP_Compass_Backend *AP_Compass_IST8310::probe(AP_HAL::OwnPtr<AP_HAL::Device> dev
     return sensor;
 }
 
-AP_Compass_IST8310::AP_Compass_IST8310(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+AP_Compass_IST8310::AP_Compass_IST8310(AP_HAL::Device &dev,
                                        bool force_external,
                                        enum Rotation rotation)
-    : _dev(std::move(dev))
+    : _dev(&dev)
     , _rotation(rotation)
     , _force_external(force_external)
 {

--- a/libraries/AP_Compass/AP_Compass_IST8310.h
+++ b/libraries/AP_Compass/AP_Compass_IST8310.h
@@ -38,14 +38,14 @@
 class AP_Compass_IST8310 : public AP_Compass_Backend
 {
 public:
-    static AP_Compass_Backend *probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+    static AP_Compass_Backend *probe(AP_HAL::Device &dev,
                                      bool force_external,
                                      enum Rotation rotation);
 
     static constexpr const char *name = "IST8310";
 
 private:
-    AP_Compass_IST8310(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+    AP_Compass_IST8310(AP_HAL::Device &dev,
                        bool force_external,
                        enum Rotation rotation);
 
@@ -53,7 +53,7 @@ private:
     bool init();
     void start_conversion();
 
-    AP_HAL::OwnPtr<AP_HAL::Device> _dev;
+    AP_HAL::Device *_dev;
     AP_HAL::Device::PeriodicHandle _periodic_handle;
 
     enum Rotation _rotation;

--- a/libraries/AP_Compass/AP_Compass_LIS2MDL.cpp
+++ b/libraries/AP_Compass/AP_Compass_LIS2MDL.cpp
@@ -22,7 +22,6 @@
 #include "AP_Compass_LIS2MDL.h"
 
 #include <AP_HAL/AP_HAL.h>
-#include <utility>
 #include <AP_Math/AP_Math.h>
 #include <stdio.h>
 
@@ -37,14 +36,11 @@
 // WHO_AM_I device ID
 #define ID_WHO_AM_I         0x40
 
-AP_Compass_Backend *AP_Compass_LIS2MDL::probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+AP_Compass_Backend *AP_Compass_LIS2MDL::probe(AP_HAL::Device &dev,
                                               bool force_external,
                                               enum Rotation rotation)
 {
-    if (!dev) {
-        return nullptr;
-    }
-    AP_Compass_LIS2MDL *sensor = NEW_NOTHROW AP_Compass_LIS2MDL(std::move(dev), force_external, rotation);
+    AP_Compass_LIS2MDL *sensor = NEW_NOTHROW AP_Compass_LIS2MDL(dev, force_external, rotation);
     if (!sensor || !sensor->init()) {
         delete sensor;
         return nullptr;
@@ -53,10 +49,10 @@ AP_Compass_Backend *AP_Compass_LIS2MDL::probe(AP_HAL::OwnPtr<AP_HAL::Device> dev
     return sensor;
 }
 
-AP_Compass_LIS2MDL::AP_Compass_LIS2MDL(AP_HAL::OwnPtr<AP_HAL::Device> _dev,
+AP_Compass_LIS2MDL::AP_Compass_LIS2MDL(AP_HAL::Device &_dev,
                                        bool _force_external,
                                        enum Rotation _rotation)
-    : dev(std::move(_dev))
+    : dev(&_dev)
     , force_external(_force_external)
     , rotation(_rotation)
 {

--- a/libraries/AP_Compass/AP_Compass_LIS2MDL.h
+++ b/libraries/AP_Compass/AP_Compass_LIS2MDL.h
@@ -32,18 +32,18 @@
 class AP_Compass_LIS2MDL : public AP_Compass_Backend
 {
 public:
-    static AP_Compass_Backend *probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+    static AP_Compass_Backend *probe(AP_HAL::Device &dev,
                                      bool force_external,
                                      enum Rotation rotation);
 
     static constexpr const char *name = "LIS2MDL";
 
 private:
-    AP_Compass_LIS2MDL(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+    AP_Compass_LIS2MDL(AP_HAL::Device &dev,
                        bool force_external,
                        enum Rotation rotation);
 
-    AP_HAL::OwnPtr<AP_HAL::Device> dev;
+    AP_HAL::Device *dev;
 
     /**
      * @brief Initialize the sensor

--- a/libraries/AP_Compass/AP_Compass_LIS3MDL.cpp
+++ b/libraries/AP_Compass/AP_Compass_LIS3MDL.cpp
@@ -22,7 +22,6 @@
 #if AP_COMPASS_LIS3MDL_ENABLED
 
 #include <AP_HAL/AP_HAL.h>
-#include <utility>
 #include <AP_Math/AP_Math.h>
 #include <stdio.h>
 
@@ -48,14 +47,11 @@
 #define ADDR_WHO_AM_I       0x0f
 #define ID_WHO_AM_I         0x3d
 
-AP_Compass_Backend *AP_Compass_LIS3MDL::probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+AP_Compass_Backend *AP_Compass_LIS3MDL::probe(AP_HAL::Device &dev,
                                               bool force_external,
                                               enum Rotation rotation)
 {
-    if (!dev) {
-        return nullptr;
-    }
-    AP_Compass_LIS3MDL *sensor = NEW_NOTHROW AP_Compass_LIS3MDL(std::move(dev), force_external, rotation);
+    AP_Compass_LIS3MDL *sensor = NEW_NOTHROW AP_Compass_LIS3MDL(dev, force_external, rotation);
     if (!sensor || !sensor->init()) {
         delete sensor;
         return nullptr;
@@ -64,10 +60,10 @@ AP_Compass_Backend *AP_Compass_LIS3MDL::probe(AP_HAL::OwnPtr<AP_HAL::Device> dev
     return sensor;
 }
 
-AP_Compass_LIS3MDL::AP_Compass_LIS3MDL(AP_HAL::OwnPtr<AP_HAL::Device> _dev,
+AP_Compass_LIS3MDL::AP_Compass_LIS3MDL(AP_HAL::Device &_dev,
                                        bool _force_external,
                                        enum Rotation _rotation)
-    : dev(std::move(_dev))
+    : dev(&_dev)
     , force_external(_force_external)
     , rotation(_rotation)
 {

--- a/libraries/AP_Compass/AP_Compass_LIS3MDL.h
+++ b/libraries/AP_Compass/AP_Compass_LIS3MDL.h
@@ -37,19 +37,19 @@
 class AP_Compass_LIS3MDL : public AP_Compass_Backend
 {
 public:
-    static AP_Compass_Backend *probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+    static AP_Compass_Backend *probe(AP_HAL::Device &dev,
                                      bool force_external,
                                      enum Rotation rotation);
 
     static constexpr const char *name = "LIS3MDL";
 
 private:
-    AP_Compass_LIS3MDL(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+    AP_Compass_LIS3MDL(AP_HAL::Device &dev,
                        bool force_external,
                        enum Rotation rotation);
 
-    AP_HAL::OwnPtr<AP_HAL::Device> dev;
-    
+    AP_HAL::Device *dev;
+
     /**
      * Device periodic callback to read data from the sensor.
      */

--- a/libraries/AP_Compass/AP_Compass_LSM303D.cpp
+++ b/libraries/AP_Compass/AP_Compass_LSM303D.cpp
@@ -17,8 +17,6 @@
 
 #if AP_COMPASS_LSM303D_ENABLED
 
-#include <utility>
-
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
 
@@ -153,18 +151,15 @@ extern const AP_HAL::HAL &hal;
 #define LSM303D_MAG_DEFAULT_RANGE_GA          2
 #define LSM303D_MAG_DEFAULT_RATE            100
 
-AP_Compass_LSM303D::AP_Compass_LSM303D(AP_HAL::OwnPtr<AP_HAL::Device> dev)
-    : _dev(std::move(dev))
+AP_Compass_LSM303D::AP_Compass_LSM303D(AP_HAL::Device &dev)
+    : _dev(&dev)
 {
 }
 
-AP_Compass_Backend *AP_Compass_LSM303D::probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+AP_Compass_Backend *AP_Compass_LSM303D::probe(AP_HAL::Device &dev,
                                               enum Rotation rotation)
 {
-    if (!dev) {
-        return nullptr;
-    }
-    AP_Compass_LSM303D *sensor = NEW_NOTHROW AP_Compass_LSM303D(std::move(dev));
+    AP_Compass_LSM303D *sensor = NEW_NOTHROW AP_Compass_LSM303D(dev);
     if (!sensor || !sensor->init(rotation)) {
         delete sensor;
         return nullptr;

--- a/libraries/AP_Compass/AP_Compass_LSM303D.h
+++ b/libraries/AP_Compass/AP_Compass_LSM303D.h
@@ -15,7 +15,7 @@
 class AP_Compass_LSM303D : public AP_Compass_Backend
 {
 public:
-    static AP_Compass_Backend *probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+    static AP_Compass_Backend *probe(AP_HAL::Device &dev,
                                      enum Rotation rotation);
 
     static constexpr const char *name = "LSM303D";
@@ -25,7 +25,7 @@ public:
     virtual ~AP_Compass_LSM303D() { }
 
 private:
-    AP_Compass_LSM303D(AP_HAL::OwnPtr<AP_HAL::Device> dev);
+    AP_Compass_LSM303D(AP_HAL::Device &dev);
 
     bool init(enum Rotation rotation);
     uint8_t _register_read(uint8_t reg);
@@ -43,7 +43,7 @@ private:
     bool _mag_set_samplerate(uint16_t frequency);
 
     AP_HAL::DigitalSource *_drdy_pin_m;
-    AP_HAL::OwnPtr<AP_HAL::Device> _dev;
+    AP_HAL::Device *_dev;
 
     float _mag_range_scale;
     int16_t _mag_x;

--- a/libraries/AP_Compass/AP_Compass_LSM9DS1.cpp
+++ b/libraries/AP_Compass/AP_Compass_LSM9DS1.cpp
@@ -49,20 +49,17 @@
 
 extern const AP_HAL::HAL &hal;
 
-AP_Compass_LSM9DS1::AP_Compass_LSM9DS1(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+AP_Compass_LSM9DS1::AP_Compass_LSM9DS1(AP_HAL::Device &dev,
                                        enum Rotation rotation)
-    : _dev(std::move(dev))
+    : _dev(&dev)
     , _rotation(rotation)
 {
 }
 
-AP_Compass_Backend *AP_Compass_LSM9DS1::probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+AP_Compass_Backend *AP_Compass_LSM9DS1::probe(AP_HAL::Device &dev,
                                               enum Rotation rotation)
 {
-    if (!dev) {
-        return nullptr;
-    }
-    AP_Compass_LSM9DS1 *sensor = NEW_NOTHROW AP_Compass_LSM9DS1(std::move(dev), rotation);
+    AP_Compass_LSM9DS1 *sensor = NEW_NOTHROW AP_Compass_LSM9DS1(dev, rotation);
     if (!sensor || !sensor->init()) {
         delete sensor;
         return nullptr;

--- a/libraries/AP_Compass/AP_Compass_LSM9DS1.h
+++ b/libraries/AP_Compass/AP_Compass_LSM9DS1.h
@@ -14,7 +14,7 @@
 class AP_Compass_LSM9DS1 : public AP_Compass_Backend
 {
 public:
-    static AP_Compass_Backend *probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+    static AP_Compass_Backend *probe(AP_HAL::Device &dev,
                                      enum Rotation rotation);
 
     static constexpr const char *name = "LSM9DS1";
@@ -22,7 +22,7 @@ public:
     virtual ~AP_Compass_LSM9DS1() {}
 
 private:
-    AP_Compass_LSM9DS1(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+    AP_Compass_LSM9DS1(AP_HAL::Device &dev,
                        enum Rotation rotation);
     bool init();
     bool _check_id(void);
@@ -36,7 +36,7 @@ private:
     bool _block_read(uint8_t reg, uint8_t *buf, uint32_t size);
     void _dump_registers();
 
-    AP_HAL::OwnPtr<AP_HAL::Device> _dev;
+    AP_HAL::Device *_dev;
     float _scaling;
     enum Rotation _rotation;
 

--- a/libraries/AP_Compass/AP_Compass_MAG3110.cpp
+++ b/libraries/AP_Compass/AP_Compass_MAG3110.cpp
@@ -16,8 +16,6 @@
 
 #if AP_COMPASS_MAG3110_ENABLED
 
-#include <utility>
-
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
 #include <stdio.h>
@@ -82,18 +80,15 @@ RUS:
 
 
 
-AP_Compass_MAG3110::AP_Compass_MAG3110(AP_HAL::OwnPtr<AP_HAL::Device> dev)
-    : _dev(std::move(dev))
+AP_Compass_MAG3110::AP_Compass_MAG3110(AP_HAL::Device &dev)
+    : _dev(&dev)
 {
 }
 
-AP_Compass_Backend *AP_Compass_MAG3110::probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+AP_Compass_Backend *AP_Compass_MAG3110::probe(AP_HAL::Device &dev,
                                               enum Rotation rotation)
 {
-    if (!dev) {
-        return nullptr;
-    }
-    AP_Compass_MAG3110 *sensor = NEW_NOTHROW AP_Compass_MAG3110(std::move(dev));
+    AP_Compass_MAG3110 *sensor = NEW_NOTHROW AP_Compass_MAG3110(dev);
     if (!sensor || !sensor->init(rotation)) {
         delete sensor;
         return nullptr;

--- a/libraries/AP_Compass/AP_Compass_MAG3110.h
+++ b/libraries/AP_Compass/AP_Compass_MAG3110.h
@@ -20,7 +20,7 @@
 class AP_Compass_MAG3110 : public AP_Compass_Backend
 {
 public:
-    static AP_Compass_Backend *probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+    static AP_Compass_Backend *probe(AP_HAL::Device &dev,
                                      enum Rotation rotation);
 
     static constexpr const char *name = "MAG3110";
@@ -30,7 +30,7 @@ public:
     ~AP_Compass_MAG3110() { }
 
 private:
-    AP_Compass_MAG3110(AP_HAL::OwnPtr<AP_HAL::Device> dev);
+    AP_Compass_MAG3110(AP_HAL::Device &dev);
 
     bool init(enum Rotation rotation);
 
@@ -39,7 +39,7 @@ private:
     bool _hardware_init();
     void _update();
 
-    AP_HAL::OwnPtr<AP_HAL::Device> _dev;
+    AP_HAL::Device *_dev;
 
     int32_t _mag_x;
     int32_t _mag_y;

--- a/libraries/AP_Compass/AP_Compass_MMC3416.cpp
+++ b/libraries/AP_Compass/AP_Compass_MMC3416.cpp
@@ -20,7 +20,6 @@
 #if AP_COMPASS_MMC3416_ENABLED
 
 #include <AP_HAL/AP_HAL.h>
-#include <utility>
 #include <AP_Math/AP_Math.h>
 #include <stdio.h>
 #include <AP_Logger/AP_Logger.h>
@@ -43,14 +42,11 @@ extern const AP_HAL::HAL &hal;
 // datasheet says 50ms min for refill
 #define MIN_DELAY_SET_RESET 50
 
-AP_Compass_Backend *AP_Compass_MMC3416::probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+AP_Compass_Backend *AP_Compass_MMC3416::probe(AP_HAL::Device &dev,
                                               bool force_external,
                                               enum Rotation rotation)
 {
-    if (!dev) {
-        return nullptr;
-    }
-    AP_Compass_MMC3416 *sensor = NEW_NOTHROW AP_Compass_MMC3416(std::move(dev), force_external, rotation);
+    AP_Compass_MMC3416 *sensor = NEW_NOTHROW AP_Compass_MMC3416(dev, force_external, rotation);
     if (!sensor || !sensor->init()) {
         delete sensor;
         return nullptr;
@@ -59,10 +55,10 @@ AP_Compass_Backend *AP_Compass_MMC3416::probe(AP_HAL::OwnPtr<AP_HAL::Device> dev
     return sensor;
 }
 
-AP_Compass_MMC3416::AP_Compass_MMC3416(AP_HAL::OwnPtr<AP_HAL::Device> _dev,
+AP_Compass_MMC3416::AP_Compass_MMC3416(AP_HAL::Device &_dev,
                                        bool _force_external,
                                        enum Rotation _rotation)
-    : dev(std::move(_dev))
+    : dev(&_dev)
     , force_external(_force_external)
     , rotation(_rotation)
 {

--- a/libraries/AP_Compass/AP_Compass_MMC3416.h
+++ b/libraries/AP_Compass/AP_Compass_MMC3416.h
@@ -33,18 +33,18 @@
 class AP_Compass_MMC3416 : public AP_Compass_Backend
 {
 public:
-    static AP_Compass_Backend *probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+    static AP_Compass_Backend *probe(AP_HAL::Device &dev,
                                      bool force_external,
                                      enum Rotation rotation);
 
     static constexpr const char *name = "MMC3416";
 
 private:
-    AP_Compass_MMC3416(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+    AP_Compass_MMC3416(AP_HAL::Device &dev,
                        bool force_external,
                        enum Rotation rotation);
 
-    AP_HAL::OwnPtr<AP_HAL::Device> dev;
+    AP_HAL::Device *dev;
 
     enum {
         STATE_REFILL1,

--- a/libraries/AP_Compass/AP_Compass_MMC5xx3.cpp
+++ b/libraries/AP_Compass/AP_Compass_MMC5xx3.cpp
@@ -42,14 +42,11 @@ extern const AP_HAL::HAL &hal;
 
 #define MMC5983_ID 0x30
 
-AP_Compass_Backend *AP_Compass_MMC5XX3::probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+AP_Compass_Backend *AP_Compass_MMC5XX3::probe(AP_HAL::Device &dev,
                                               bool force_external,
                                               enum Rotation rotation)
 {
-    if (!dev) {
-        return nullptr;
-    }
-    AP_Compass_MMC5XX3 *sensor = NEW_NOTHROW AP_Compass_MMC5XX3(std::move(dev), force_external, rotation);
+    AP_Compass_MMC5XX3 *sensor = NEW_NOTHROW AP_Compass_MMC5XX3(dev, force_external, rotation);
     if (!sensor || !sensor->init()) {
         delete sensor;
         return nullptr;
@@ -58,10 +55,10 @@ AP_Compass_Backend *AP_Compass_MMC5XX3::probe(AP_HAL::OwnPtr<AP_HAL::Device> dev
     return sensor;
 }
 
-AP_Compass_MMC5XX3::AP_Compass_MMC5XX3(AP_HAL::OwnPtr<AP_HAL::Device> _dev,
+AP_Compass_MMC5XX3::AP_Compass_MMC5XX3(AP_HAL::Device &_dev,
                                        bool _force_external,
                                        enum Rotation _rotation)
-    : dev(std::move(_dev))
+    : dev(&_dev)
     , force_external(_force_external)
     , have_initial_offset(false)
     , rotation(_rotation)

--- a/libraries/AP_Compass/AP_Compass_MMC5xx3.h
+++ b/libraries/AP_Compass/AP_Compass_MMC5xx3.h
@@ -33,18 +33,18 @@
 class AP_Compass_MMC5XX3 : public AP_Compass_Backend
 {
 public:
-    static AP_Compass_Backend *probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+    static AP_Compass_Backend *probe(AP_HAL::Device &dev,
                                      bool force_external,
                                      enum Rotation rotation);
 
     static constexpr const char *name = "MMC5983";
 
 private:
-    AP_Compass_MMC5XX3(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+    AP_Compass_MMC5XX3(AP_HAL::Device &dev,
                        bool force_external,
                        enum Rotation rotation);
 
-    AP_HAL::OwnPtr<AP_HAL::Device> dev;
+    AP_HAL::Device *dev;
 
     enum class MMCState {
         STATE_SET,

--- a/libraries/AP_Compass/AP_Compass_QMC5883L.cpp
+++ b/libraries/AP_Compass/AP_Compass_QMC5883L.cpp
@@ -22,7 +22,6 @@
 #if AP_COMPASS_QMC5883L_ENABLED
 
 #include <stdio.h>
-#include <utility>
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/utility/sparse-endian.h>
@@ -57,15 +56,11 @@
 #define QMC5883L_REG_ID 0x0D
 #define QMC5883_ID_VAL 0xFF
 
-AP_Compass_Backend *AP_Compass_QMC5883L::probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+AP_Compass_Backend *AP_Compass_QMC5883L::probe(AP_HAL::Device &dev,
                                                bool force_external,
                                                enum Rotation rotation)
 {
-    if (!dev) {
-        return nullptr;
-    }
-
-    AP_Compass_QMC5883L *sensor = NEW_NOTHROW AP_Compass_QMC5883L(std::move(dev),force_external,rotation);
+    AP_Compass_QMC5883L *sensor = NEW_NOTHROW AP_Compass_QMC5883L(dev, force_external, rotation);
     if (!sensor || !sensor->init()) {
         delete sensor;
         return nullptr;
@@ -74,10 +69,10 @@ AP_Compass_Backend *AP_Compass_QMC5883L::probe(AP_HAL::OwnPtr<AP_HAL::Device> de
     return sensor;
 }
 
-AP_Compass_QMC5883L::AP_Compass_QMC5883L(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+AP_Compass_QMC5883L::AP_Compass_QMC5883L(AP_HAL::Device &dev,
                                          bool force_external,
                                          enum Rotation rotation)
-    : _dev(std::move(dev))
+    : _dev(&dev)
     , _rotation(rotation)
 	, _force_external(force_external)
 {

--- a/libraries/AP_Compass/AP_Compass_QMC5883L.h
+++ b/libraries/AP_Compass/AP_Compass_QMC5883L.h
@@ -46,14 +46,14 @@
 class AP_Compass_QMC5883L : public AP_Compass_Backend
 {
 public:
-    static AP_Compass_Backend *probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+    static AP_Compass_Backend *probe(AP_HAL::Device &dev,
 									 bool force_external,
                                      enum Rotation rotation);
 
     static constexpr const char *name = "QMC5883L";
 
 private:
-    AP_Compass_QMC5883L(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+    AP_Compass_QMC5883L(AP_HAL::Device &dev,
                         bool force_external,
                         enum Rotation rotation);
 
@@ -62,7 +62,7 @@ private:
     void timer();
     bool init();
 
-    AP_HAL::OwnPtr<AP_HAL::Device> _dev;
+    AP_HAL::Device *_dev;
 
     enum Rotation _rotation;
     bool _force_external;

--- a/libraries/AP_Compass/AP_Compass_QMC5883P.cpp
+++ b/libraries/AP_Compass/AP_Compass_QMC5883P.cpp
@@ -73,14 +73,11 @@
 #define DEBUG 0
 #endif
 
-AP_Compass_Backend *AP_Compass_QMC5883P::probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+AP_Compass_Backend *AP_Compass_QMC5883P::probe(AP_HAL::Device &dev,
         bool force_external,
         enum Rotation rotation)
 {
-    if (!dev) {
-        return nullptr;
-    }
-    AP_Compass_QMC5883P *sensor = NEW_NOTHROW AP_Compass_QMC5883P(std::move(dev),force_external,rotation);
+    AP_Compass_QMC5883P *sensor = NEW_NOTHROW AP_Compass_QMC5883P(dev, force_external, rotation);
     if (!sensor || !sensor->init()) {
         delete sensor;
         return nullptr;
@@ -88,10 +85,10 @@ AP_Compass_Backend *AP_Compass_QMC5883P::probe(AP_HAL::OwnPtr<AP_HAL::Device> de
     return sensor;
 }
 
-AP_Compass_QMC5883P::AP_Compass_QMC5883P(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+AP_Compass_QMC5883P::AP_Compass_QMC5883P(AP_HAL::Device &dev,
         bool force_external,
         enum Rotation rotation)
-    : _dev(std::move(dev))
+    : _dev(&dev)
     , _rotation(rotation)
     , _force_external(force_external)
 {

--- a/libraries/AP_Compass/AP_Compass_QMC5883P.h
+++ b/libraries/AP_Compass/AP_Compass_QMC5883P.h
@@ -45,14 +45,14 @@
 class AP_Compass_QMC5883P : public AP_Compass_Backend
 {
 public:
-    static AP_Compass_Backend *probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+    static AP_Compass_Backend *probe(AP_HAL::Device &dev,
                                      bool force_external,
                                      enum Rotation rotation);
 
     static constexpr const char *name = "QMC5883P";
 
 private:
-    AP_Compass_QMC5883P(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+    AP_Compass_QMC5883P(AP_HAL::Device &dev,
                         bool force_external,
                         enum Rotation rotation);
 
@@ -61,7 +61,7 @@ private:
     void timer();
     bool init();
 
-    AP_HAL::OwnPtr<AP_HAL::Device> _dev;
+    AP_HAL::Device *_dev;
 
     enum Rotation _rotation;
     bool _force_external;

--- a/libraries/AP_Compass/AP_Compass_RM3100.cpp
+++ b/libraries/AP_Compass/AP_Compass_RM3100.cpp
@@ -22,7 +22,6 @@
 #if AP_COMPASS_RM3100_ENABLED
 
 #include <AP_HAL/AP_HAL.h>
-#include <utility>
 #include <AP_Math/AP_Math.h>
 #include <stdio.h>
 
@@ -67,14 +66,11 @@
 
 extern const AP_HAL::HAL &hal;
 
-AP_Compass_Backend *AP_Compass_RM3100::probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+AP_Compass_Backend *AP_Compass_RM3100::probe(AP_HAL::Device &dev,
                                               bool force_external,
                                               enum Rotation rotation)
 {
-    if (!dev) {
-        return nullptr;
-    }
-    AP_Compass_RM3100 *sensor = NEW_NOTHROW AP_Compass_RM3100(std::move(dev), force_external, rotation);
+    AP_Compass_RM3100 *sensor = NEW_NOTHROW AP_Compass_RM3100(dev, force_external, rotation);
     if (!sensor || !sensor->init()) {
         delete sensor;
         return nullptr;
@@ -83,10 +79,10 @@ AP_Compass_Backend *AP_Compass_RM3100::probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
     return sensor;
 }
 
-AP_Compass_RM3100::AP_Compass_RM3100(AP_HAL::OwnPtr<AP_HAL::Device> _dev,
+AP_Compass_RM3100::AP_Compass_RM3100(AP_HAL::Device &_dev,
                                        bool _force_external,
                                        enum Rotation _rotation)
-    : dev(std::move(_dev))
+    : dev(&_dev)
     , force_external(_force_external)
     , rotation(_rotation)
 {

--- a/libraries/AP_Compass/AP_Compass_RM3100.h
+++ b/libraries/AP_Compass/AP_Compass_RM3100.h
@@ -36,19 +36,19 @@
 class AP_Compass_RM3100 : public AP_Compass_Backend
 {
 public:
-    static AP_Compass_Backend *probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+    static AP_Compass_Backend *probe(AP_HAL::Device &dev,
                                      bool force_external,
                                      enum Rotation rotation);
 
     static constexpr const char *name = "RM3100";
 
 private:
-    AP_Compass_RM3100(AP_HAL::OwnPtr<AP_HAL::Device> dev,
+    AP_Compass_RM3100(AP_HAL::Device &dev,
                        bool force_external,
                        enum Rotation rotation);
 
-    AP_HAL::OwnPtr<AP_HAL::Device> dev;
-    
+    AP_HAL::Device *dev;
+
     /**
      * Device periodic callback to read data from the sensor.
      */

--- a/libraries/AP_HAL/hwdef/scripts/hwdef.py
+++ b/libraries/AP_HAL/hwdef/scripts/hwdef.py
@@ -458,6 +458,10 @@ class HWDef:
             if len(a) > 1 and a[1].startswith('probe'):
                 probe = a[1]
 
+            # these two are aliases:
+            if probe == 'probe_ICM20948_SPI':
+                probe = 'probe_ICM20948'
+
             expected_device_count = 1
             if driver == 'AK09916' and probe == 'probe_ICM20948':
                 expected_device_count = 1
@@ -527,30 +531,65 @@ class HWDef:
             n = len(devlist)+1
             devlist.append('HAL_MAG_PROBE%u' % n)
 
-            args = []
-            for dev in compass.devlist:
-                if isinstance(dev, I2CDev):
-                    if dev.buses_to_probe == 'SINGLE':
-                        busnum = str(dev.busnum)
-                    elif dev.buses_to_probe in {'ALL', 'ALL_EXTERNAL', 'ALL_INTERNAL'}:
-                        busnum = 'b'
-                    else:
-                        raise ValueError("Unexpected {buses_to_probe=}")
-                    args.extend(["GET_I2C_DEVICE(%s,0x%02x)" % (busnum, dev.busaddr)])
-                elif isinstance(dev, SPIDev):
-                    args.extend([f'hal.spi->get_device("{dev.name}")'])
-                elif dev.isdigit():
-                    args.extend([str(dev)])
+            def i2c_dev_as_arguments_string(dev):
+                if dev.buses_to_probe == 'SINGLE':
+                    busnum = str(dev.busnum)
+                elif dev.buses_to_probe in {'ALL', 'ALL_EXTERNAL', 'ALL_INTERNAL'}:
+                    busnum = 'b'
                 else:
-                    raise ValueError("unexpected devbit {dev=}")
+                    raise ValueError("Unexpected {buses_to_probe=}")
+                return "%s, 0x%02x" % (busnum, dev.busaddr)
 
-            if compass.force_external is not None:
-                args.append(str(compass.force_external))
-            args.append(str(compass.rotation))
+            args = []
+            if probe == "probe":
+                for dev in compass.devlist:
+                    if isinstance(dev, I2CDev):
+                        compass_probe_method = 'probe_i2c_dev'
+                        args.append(f"DRIVER_{compass.driver}")
+                        args.append(f'AP_Compass_{compass.driver}::probe')
+                        args.append(i2c_dev_as_arguments_string(dev))
+                    elif isinstance(dev, SPIDev):
+                        compass_probe_method = 'probe_spi_dev'
+                        args.append(f"DRIVER_{compass.driver}")
+                        args.append(f'AP_Compass_{compass.driver}::probe')
+                        args.append(f'"{dev.name}"')
+                    elif dev.isdigit():
+                        args.append(str(dev))
+                    else:
+                        raise ValueError("unexpected devbit {dev=}")
 
-            f.write(
-                '#define HAL_MAG_PROBE%u %s {add_backend(DRIVER_%s, AP_Compass_%s::%s(%s));RETURN_IF_NO_SPACE;}\n'
-                % (n, wrapper, driver, driver, probe, ','.join(args)))
+                if compass.force_external is not None:
+                    args.append(str(compass.force_external))
+                args.append(str(compass.rotation))
+            elif probe == 'probe_ICM20948':
+                compass_probe_method = 'probe_ak09916_via_icm20948'
+                if len(compass.devlist) != 1:
+                    raise ValueError(f"Expected 0 arguments for {probe} ({compass.devlist=}")
+                if isinstance(compass.devlist[0], I2CDev):
+                    devstring = i2c_dev_as_arguments_string(compass.devlist[0])
+                else:
+                    devstring = compass.devlist[0]
+                args.append(devstring)
+                if compass.force_external is not None:
+                    args.append(str(compass.force_external))
+                args.append(str(compass.rotation))
+            elif probe == 'probe_mpu9250':
+                compass_probe_method = 'probe_ak8963_via_mpu9250'
+                if len(compass.devlist) != 1:
+                    raise ValueError(f"Expected 0 arguments for {probe} ({compass.devlist=}")
+                if isinstance(compass.devlist[0], I2CDev):
+                    devstring = i2c_dev_as_arguments_string(compass.devlist[0])
+                else:
+                    devstring = compass.devlist[0]
+                args.append(devstring)
+                if compass.force_external is not None:
+                    args.append(str(compass.force_external))
+                args.append(str(compass.rotation))
+            else:
+                raise ValueError(f"Unknown probe method {probe=}")
+
+            f.write(f'#define HAL_MAG_PROBE{n} {wrapper} {{{compass_probe_method}({", ".join(args)});RETURN_IF_NO_SPACE;}}\n')
+
             f.write(f"#undef AP_COMPASS_{driver}_ENABLED\n#define AP_COMPASS_{driver}_ENABLED 1\n")
         if len(devlist) > 0:
             f.write('#define HAL_MAG_PROBE_LIST %s\n\n' % ';'.join(devlist))


### PR DESCRIPTION
### Summary

Stops using OwnPtr in the compass library.

Into the future will allow further tidying of probing (removing external and rotation arguments not needed for probing), and removal of resource leaks (e.g. compass backend pointers when add_backend fails.

Fixed a release of bus pointer in the case of an allocation failure for sensor (minor problem, may not be worth the flash, maybe just comment it instead?

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli   iofirmware  plane  rover  sub
CubeOrange-periph-heavy  -904                              *                                                    
Durandal                            -1080           -1080  *           -1080   -1080              -1080  -1080  -1080
Hitec-Airspeed           *                                 *                                                    
KakuteH7-bdshot                     -920            -920   *           -920    -920               -920   -920   -920
MatekF405                           -744            -744   *           -736    -744               -744   -744   -736
MatekH7A3                           -920            -920   *           -920    -920               -920   -920   -920
Pixhawk1-1M-bdshot                  -720            -720               -720    -720               -720   -720   -720
SITL_x86_64_linux_gnu               *               *                  *       *                  *      *      *
YJUAV_A6SE                          -1104           -1104  *           -1088   -1072              -1072  -1072  -1072
f103-QiotekPeriph        -648                              *                                                    
f303-MatekGPS            -32                               *                                                    
f303-Universal           -664                              *                                                    
iomcu                                                                                 *                         
mindpx-v2                           -1048           -1048  *           -1048   -1048              -1048  -1048  -1048
revo-mini                           -32             -32    *           -40     -40                -32    -32    -40
skyviper-v2450                                                         -32                                      
speedybeef4                         -736            -736   *           -736    -736               -736   -736   -744
```


### Description

